### PR TITLE
setup commands fix

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -8,7 +8,8 @@ used in the current version of this lesson:
 
 ```r
 install.packages("BiocManager")
-download.file("https://raw.githubusercontent.com/carpentries-incubator/high-dimensional-stats-r/gh-pages/dependencies.csv")
+download.file("https://raw.githubusercontent.com/carpentries-incubator/high-dimensional-stats-r/gh-pages/dependencies.csv",
+              destfile = 'dependencies.csv')
 table <- read.table('dependencies.csv')
 BiocManager::install(table[[1]])
 
@@ -23,7 +24,7 @@ data_files <- c(
 for (file in data_files) {
     download.file(
         url = file.path(
-            "https://raw.githubusercontent.com/carpentries-incubator/high-dimensional-stats-r/gh-pages",
+            "https://raw.githubusercontent.com/carpentries-incubator/high-dimensional-stats-r/gh-pages/data",
             file
         ),
         destfile = file.path("data", file)


### PR DESCRIPTION
Small fixes for local setup.

- download.file fails without "destfile" argument
- URL for data files is incomplete (missing "/data") and gives 404 error.