### PR TITLE
Linux caveat to setup

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -40,4 +40,13 @@ for (file in data_files) {
 }
 ```
 
+On Linux systems, part of the above may fail due to the **`bluster`** package. If you received error messages after running `BiocManager::install(table[[1]])` indicating that this package was not installed successfully, you may need to run the following workaround code after the code above:
+
+```r
+install.packages('igraph', repos=c(igraph = 'https://igraph.r-universe.dev', 
+                                   CRAN = 'https://cloud.r-project.org'))
+                                   
+BiocManager::install('bluster')
+```
+
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -40,7 +40,9 @@ for (file in data_files) {
 }
 ```
 
-On Linux systems, part of the above may fail due to the **`bluster`** package. If you received error messages after running `BiocManager::install(table[[1]])` indicating that this package was not installed successfully, you may need to run the following workaround code after the code above:
+On Linux systems, part of the above may fail due to the **`bluster`** package and you may receive error messages after running `BiocManager::install(table[[1]])`, indicating that the package `igraph` was not installed successfully. 
+
+Detailed installation instructions for `igraph` can be found at [https://r.igraph.org/](https://r.igraph.org/), but the following workaround code may resolve the issue:
 
 ```r
 install.packages('igraph', repos=c(igraph = 'https://igraph.r-universe.dev', 


### PR DESCRIPTION
Linux needs additional system software to install the bluster package. Works with the development version added (see https://r.igraph.org/ for more info)

