### PR TITLE
changes to episode 4, tasks 28-29

### DIFF
--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -321,7 +321,8 @@ This package provides several functions that are useful for exploring data via P
 producing useful figures and analysis tools. The package is made for the somewhat unusual
 Bioconductor style of data tables (observations in columns, features in rows). When
 using Bioconductor data sets and **`PCAtools`**, it is thus not necessary to transpose the data.
-Note that, although we focus on PCA implementation using **`PCAtools`**, there are several other
+You can use the help files in PCAtools to find out about the `pca()`
+function (type `help("pca")` or `?pca` in R). Note that, although we focus on PCA implementation using **`PCAtools`**, there are several other
 options for performing PCA, including a base R function, `prcomp()`. Equivalent functions and 
 output labels for the common implementations are summarised below.
 
@@ -332,7 +333,7 @@ output labels for the common implementations are summarised below.
 | PCAtools::pca()   | $rotated   | $loadings | 
 
 
-Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. First, let's load the **`PCAtools`** package and the data.
+Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. First, let's load the **`PCAtools`** package.
 
 ```{r pcatools}
 library("PCAtools")
@@ -340,8 +341,7 @@ library("PCAtools")
 
 
 The input data (`pros2`) is in the form of a matrix and we need to take the transpose of this 
-matrix for use within the **`PCAtools`** package. We set the `scale = TRUE` argument
-to standardise the variables to have a mean 0 and standard deviation of 1 as above. 
+matrix and convert it to a data frame for use within the **`PCAtools`** package. We set the `scale = TRUE` argument to standardise the variables to have a mean 0 and standard deviation of 1 as above. 
 
 ```{r prcomp}
 pros2t <- data.frame(t(pros2))  #create transposed data frame
@@ -367,7 +367,7 @@ prop.var
 ```
 
 This returns the proportion of variance in the data explained by each of the
-(p = 5) principal components. In this example, the first principal component, PC1, explains approximately
+principal components. In this example, the first principal component, PC1, explains approximately
 `r round(prop.var[[1]])`% of variance in the data, PC2 `r round(prop.var[[2]])`% of variance,
 PC3 a further `r round(prop.var[[3]])`%, PC4 approximately `r round(prop.var[[4]])`% and PC5
 around `r round(prop.var[[5]])`%.
@@ -382,20 +382,20 @@ which may be discarded after the elbow.
 
 We can create a scree plot using the **`PCAtools`** function `screeplot()`:
 
-
 ```{r varexp}
-screeplot(pca.pros, axisLabSize = 5, titleLabSize = 8)
+screeplot(pca.pros, axisLabSize = 5, titleLabSize = 8, 
+          drawCumulativeSumLine = FALSE, drawCumulativeSumPoints = FALSE) +
+    geom_line(aes(x = 1:length(pca.pros$components), y = as.numeric(pca.pros$variance))) 
+#add line to scree plot to visualise the elbow
 ```
 
-The scree plot (blue bars) show that the first principal component explains most of the
-variance in the data (>50%) and each subsequent principal component explains
-less and less of the total variance. The red line displays the cumulative variance explained
-by the principal components and shows that the first two principal components
-explain >70% of variance in the data. But what do these two principal
-components mean?
+The scree plot shows that the first principal component explains most of the
+variance in the data (>50%), the first two principal components
+explain >70% of variance in the data, and and each subsequent principal component explains
+less and less of the total variance.
 
 
-## What are loadings and principal component scores?
+## Loadings and principal component scores
 
 Most PCA functions will produce two main output matrices: the
 *principal component scores* and the *loadings*. The matrix of principal component scores
@@ -544,7 +544,7 @@ representing groups of genes would help visualise the data and address
 research questions regarding the effect different groups of genes have on
 disease progression.
 
-Using the **`PCAtools`** we will apply a PCA to the cancer
+Using the **`PCAtools`**, we will apply a PCA to the cancer
 gene expression data, plot the amount of variation in the data explained by
 each principal component and plot the most important principal components
 against each other as well as understanding what each principal component
@@ -554,8 +554,7 @@ represents.
 > ## Challenge 3
 > 
 > Apply a PCA to the cancer gene expression data using the `pca()` function from
-> **`PCAtools`**. You can use the help files in PCAtools to find out about the `pca()`
-> function (type `help("pca")` or `?pca` in R).
+> **`PCAtools`**. 
 > 
 > Let us assume we only care about the principal components accounting for the top
 > 80% of the variance in the dataset. Use the `removeVar` argument in `pca()` to remove
@@ -639,14 +638,15 @@ proportion of variance explained.
 > > 
 > > ```{r scree-ex, fig.cap="Caption", fig.cap="Alt"}
 > > pc <- pca(mat, metadata = metadata)
-> > screeplot(pc, axisLabSize = 5, titleLabSize = 8)
-> > ```
-> > The red line shows the cumulative percentage of explained
-> > variation with increasing principal components. The first 
-> > principal component explains around 33% of the 
+> > screeplot(pc, axisLabSize = 5, titleLabSize = 8, drawCumulativeSumLine = FALSE, 
+> > drawCumulativeSumPoints > > = FALSE) +  geom_line(aes(x = 1:length(pc$components), y = 
+> > as.numeric(pc$variance))) #add line to scree plot to visualise the elbow
+> > ``` 
+> > 
+> > The first principal component explains around 33% of the 
 > > variance in the microarray data, the first 4 principal components explain
 > > around 50%, and 20 principal components explain around 75%. Many principal 
-> > components explain very little variation. Looking at the scree plot, the
+> > components explain very little variation. The
 > > 'elbow' appears to be around 4-5 principal components, indicating that this
 > > may be a suitable number of principal components. However, these principal components 
 > > cumulatively explain only 51-55% of the variance in the dataset. Although the fact we 

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -316,13 +316,13 @@ deviation of 1.
 
 ## Performing PCA
 
-Throughout this episode, we will carry out PCA using the Bioconductor package `PCAtools`.
+Throughout this episode, we will carry out PCA using the Bioconductor package **`PCAtools`**.
 This package provides several functions that are useful for exploring data via PCA and
 producing useful figures and analysis tools. The package is made for the somewhat unusual
 Bioconductor style of data tables (observations in columns, features in rows). When
-using Bioconductor data sets and `PCAtools`, it is thus not necessary to transpose the data.
+using Bioconductor data sets and **`PCAtools`**, it is thus not necessary to transpose the data.
 You can use the help files in PCAtools to find out about the `pca()`
-function (type `help("pca")` or `?pca` in R). Note that, although we focus on PCA implementation using `PCAtools`, there are several other
+function (type `help("pca")` or `?pca` in R). Note that, although we focus on PCA implementation using **`PCAtools`**, there are several other
 options for performing PCA, including a base R function, `prcomp()`. Equivalent functions and 
 output labels for the common implementations are summarised below.
 
@@ -333,7 +333,7 @@ output labels for the common implementations are summarised below.
 | PCAtools::pca()   | $rotated   | $loadings | 
 
 
-Let's use the `PCAtools` package to perform PCA on the scaled `prostate` data. First, let's load the `PCAtools` package.
+Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. First, let's load the **`PCAtools`** package.
 
 ```{r pcatools}
 library("PCAtools")
@@ -341,7 +341,7 @@ library("PCAtools")
 
 
 The input data (`pros2`) is in the form of a matrix and we need to take the transpose of this 
-matrix and convert it to a data frame for use within the `PCAtools` package. We set the `scale = TRUE` argument to standardise the variables to have a mean 0 and standard deviation of 1 as above. 
+matrix and convert it to a data frame for use within the **`PCAtools`** package. We set the `scale = TRUE` argument to standardise the variables to have a mean 0 and standard deviation of 1 as above. 
 
 ```{r prcomp}
 pros2t <- data.frame(t(pros2))  #create transposed data frame
@@ -380,7 +380,7 @@ variance decreases more slowly. The total variance explained up to the elbow poi
 interpreted as structural variance that is relevant and should be retained versus noise
 which may be discarded after the elbow. 
 
-We can create a scree plot using the `PCAtools` function `screeplot()`:
+We can create a scree plot using the **`PCAtools`** function `screeplot()`:
 
 ```{r varexp, fig.cap="Scree plot showing the percentage of the variance explained by the principal components calculated from the prostate data.", fig.alt="A scree plot showing the percentage of variance explained by each principal component versus the principal component number. The points are joined by lines to indicate where the elbow of the scree plot occurs."}
 screeplot(pca.pros, axisLabSize = 5, titleLabSize = 8, 
@@ -421,7 +421,7 @@ The matrix of loadings (also called rotation matrix) has as many rows as there
 are features in the original data. It contains information about how the
 (usually centered and scaled) original data relate to the principal component scores.
 
-We can print the loadings for the `PCAtools` implementation using 
+We can print the loadings for the **`PCAtools`** implementation using 
 
 ```{r pca-pros}
 pca.pros$loadings
@@ -560,7 +560,7 @@ representing groups of genes would help visualise the data and address
 research questions regarding the effect different groups of genes have on
 disease progression.
 
-Using `PCAtools`, we will perform PCA on the cancer
+Using **`PCAtools`**, we will perform PCA on the cancer
 gene expression data, plot the amount of variation in the data explained by
 each principal component and plot the most important principal components
 against each other as well as understanding what each principal component
@@ -570,7 +570,7 @@ represents.
 > ## Challenge 3
 > 
 > Apply a PCA to the cancer gene expression data using the `pca()` function from
-> `PCAtools`. 
+> **`PCAtools`**. 
 > 
 > Let us assume we only care about the principal components accounting for the top
 > 80% of the variance in the dataset. Use the `removeVar` argument in `pca()` to remove
@@ -645,7 +645,7 @@ amount of the variation. The proportion of variance explained should sum to one.
 
 > ## Challenge 4
 > 
-> Using the `screeplot()` function in `PCAtools`, create a scree plot to show 
+> Using the `screeplot()` function in **`PCAtools`**, create a scree plot to show 
 > proportion of variance explained by each principal component. Explain the
 > output of the screeplot in terms of proportion of the variance in the data explained
 > by each principal component.
@@ -683,14 +683,14 @@ This will allow any potential clustering of points according to demographic or
 phenotypic variables to be seen.
 
 We can use biplots to look for patterns in the output from the PCA. Note that there
-are two functions called `biplot()`, one in the package `PCAtools` and one in
+are two functions called `biplot()`, one in the package **`PCAtools`** and one in
 **`stats`**. Both functions produce biplots but their scales are different!
 
 
 > ## Challenge 5
 > 
 > Create a biplot of the first two principal components from your PCA
-> using `biplot()` function in `PCAtools`. See `help("PCAtools::biplot")` for
+> using `biplot()` function in **`PCAtools`**. See `help("PCAtools::biplot")` for
 > arguments and their meaning. For instance, `lab` or `colby` may be useful.
 > 
 > Examine whether the data appear to form clusters. Explain your results.
@@ -705,7 +705,7 @@ are two functions called `biplot()`, one in the package `PCAtools` and one in
 > > axis according to expressions of different genes while no separation can be
 > > seem along the PC2 axis. Labels of patient samples are automatically added
 > > in the biplot. Labels for each sample are added by default, but can be
-> > removed if there is too much overlap in names. Note that `PCAtools` does
+> > removed if there is too much overlap in names. Note that **`PCAtools`** does
 > > not scale biplot in the same way as biplot using the stats package.
 > {: .solution}
 {: .challenge}
@@ -737,7 +737,7 @@ Let's consider this biplot in more detail, and also display the loadings:
 {: .challenge}
 
 So far, we have only looked at a biplot of PC1 versus PC2 which only gives part
-of the picture. The `pairplots()` function in `PCAtools` can be used to create
+of the picture. The `pairplots()` function in **`PCAtools`** can be used to create
 multiple biplots including different principal components.
 
 ```{r pairsplot, fig.cap="Multiple biplots produced by pairsplot().", fig.alt="An upper triangular grid of scatter plots of each principal component versus the others."}
@@ -753,7 +753,7 @@ you to set custom colours.
 
 Finally, it can sometimes be of interest to compare how certain variables contribute
 to different principal components. This can be visualised with `plotloadings()` from
-the `PCAtools` package. The function checks the range of loadings for each
+the **`PCAtools`** package. The function checks the range of loadings for each
 principal component specified (default: first five principal components). It then selects the features
 in the top and bottom 5% of these ranges and displays their loadings. This behaviour
 can be adjusted with the `rangeRetain` argument, which has 0.1 as the default value (i.e.

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -314,10 +314,27 @@ deviation of 1.
 > {: .solution}
 {: .challenge}
 
-Next we will carry out a PCA using the `prcomp()` function in base R. The input
-data (`pros2`) is in the form of a matrix. Note that the `scale = TRUE` argument
-is used to standardise the variables to have a mean 0 and standard deviation of
-1.
+## Performing PCA
+
+Throughout this episode, we will carry out a PCA using the Bioconductor package **`PCAtools`**.
+This package provides several functions that can be used to explore data via PCA and
+produce useful figures and analysis tools. The package is made for the somewhat unusual
+Bioconductor style of data tables (observations in columns, features in rows). When
+using Bioconductor data sets and **`PCAtools`**, it is thus not necessary to transpose the data.
+Note that, although we focus on PCA implementation using **`PCAtools`**, there are several other
+options for performing PCA, including a base R function, `prcomp()`. Equivalent functions for 
+the common implementations are summarised below.
+
+| library::command()| PC scores | Loadings |
+|-------------------|-----------|----------|
+| stats::prcomp()   | $x         | $rotation |
+| stats::princomp() | $scores    | $loadings | 
+| PCAtools::pca()   | $rotated   | $loadings | 
+
+
+Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. The input
+data (`pros2`) is in the form of a matrix and we set the `scale = TRUE` argument
+to standardise the variables to have a mean 0 and standard deviation of 1. 
 
 ```{r prcomp}
 pca.pros <- prcomp(pros2, scale = TRUE, center = TRUE)
@@ -452,22 +469,10 @@ loadings are scaled by the standard deviation of the principal components
 Finally, you need to know that PC scores and rotations may have different slot names, 
 depending on the PCA implementation you use. Here are some examples:
 
-| library::command()| PC scores | Loadings |
-|-------------------|-----------|----------|
-| stats::prcomp()   | $x         | $rotation |
-| stats::princomp() | $scores    | $loadings | 
-| PCAtools::pca()   | $rotated   | $loadings | 
-
 
 
 # Using PCA to analyse gene expression data 
 
-In this section you will carry out your own PCA using the Bioconductor package **`PCAtools`** 
-applied to gene expression data to explore the topics covered above. 
-**`PCAtools`** provides functions that can be used to explore data via PCA and
-produce useful figures and analysis tools. The package is made for the somewhat unusual
-Bioconductor style of data tables (observations in columns, features in rows). When
-using Bioconductor data sets and **`PCAtools`**, it is thus not necessary to transpose the data.
 
 ##  A gene expression dataset of cancer patients
 
@@ -478,7 +483,7 @@ The dataset we will be analysing in this lesson includes two subsets of data:
 * metadata associated with the gene expression results detailing information
   from patients from whom samples were taken.
 
-Let's load the **`PCAtools`** package and the data.
+In this section, we will work through Challenges and you will apply your own PCA to the high-dimensional gene expression data using what we have learnt so far. Let's load the **`PCAtools`** package and the data.
 
 ```{r pcatools}
 library("PCAtools")

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -340,11 +340,12 @@ library("PCAtools")
 
 
 The input data (`pros2`) is in the form of a matrix and we need to take the transpose of this 
-matrix for use within the **`PCAtools`** package. We set the `scale = TRUE` argument
-to standardise the variables to have a mean 0 and standard deviation of 1. 
+matrix for use within the **`PCAtools`** package. We can do this by setting the 
+`transposed = TRUE` argument. We also set the `scale = TRUE` argument
+to standardise the variables to have a mean 0 and standard deviation of 1 as above.
 
 ```{r prcomp}
-pca.pros <- pca(t(pros2), scale = TRUE, center = TRUE)
+pca.pros <- pca(t(pros2), scale = TRUE, center = TRUE, transposed = TRUE)
 pca.pros$loadings #return pca loadings 
 ```
 
@@ -382,7 +383,7 @@ We can create a scree plot using the **`PCAtools`** function `screeplot()`:
 screeplot(pca.pros, axisLabSize = 5, titleLabSize = 8)
 ```
 
-The scree plot shown by the blue bars shows that the first principal component explains most of the
+The scree plot (blue bars) show that the first principal component explains most of the
 variance in the data (>50%) and each subsequent principal component explains
 less and less of the total variance. The red line displays the cumulative variance explained
 by the principal components and shows that the first two principal components
@@ -400,11 +401,12 @@ The matrix of loadings (also called rotation matrix) has as many rows as there
 are features in the original data. It contains information about how the
 (usually centered and scaled) original data relate to the PC scores.
 
-When calling a PCA object generated with `prcomp()`, the loadings are printed by default:
+We can print the loadings for the **`PCAtools`** implementation using 
 
 ```{r pca-pros}
-pca.pros
+pca.pros$loadings
 ```
+
 
 The principal component scores are obtained by carrying out matrix multiplication of the
 (usually centered and scaled) original data times the loadings. The following
@@ -424,7 +426,7 @@ callout demonstrates this.
 > my.pros2.pcs <- pros2.scaled %*% pros2.eigen$vectors
 > # compare results
 > par(mfrow=c(1,2))
-> plot(pca.pros$x[,1:2], main="prcomp()")
+> plot(pca.pros$rotated[,1:2], main="PCAtools")
 > abline(h=0, v=0, lty=2)
 > plot(my.pros2.pcs[,1:2], main="\"By hand\"", xlab="PC1", ylab="PC2")
 > abline(h=0, v=0, lty=2)
@@ -446,7 +448,7 @@ the desired package when calling `biplot()`. A biplot of the first two principal
 components can be generated as follows:
 
 ```{r stats-biplot, fig.cap="Caption", fig.cap="Alt"}
-stats::biplot(pca.pros, xlim = c(-0.3, 0.3))
+PCAtools::biplot(pca.pros, xlim = c(-0.3, 0.3))
 ```
 
 This biplot shows the position of each patient on a 2-dimensional plot where

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -344,8 +344,8 @@ matrix for use within the **`PCAtools`** package. We set the `scale = TRUE` argu
 to standardise the variables to have a mean 0 and standard deviation of 1. 
 
 ```{r prcomp}
-pc <- pca(t(pros2), scale = TRUE, center = TRUE)
-pc$loadings #return pca loadings 
+pca.pros <- pca(t(pros2), scale = TRUE, center = TRUE)
+pca.pros$loadings #return pca loadings 
 ```
 
 # How many principal components do we need?
@@ -357,7 +357,7 @@ variation in the data, without having extra components that are unnecessary?
 Let's look at the relative importance of (percentage of the variance explained by) the components:
 
 ```{r summ}
-prop.var <- round(pc$variance, 4) #round to 4 decimal places
+prop.var <- round(pca.pros$variance, 4) #round to 4 decimal places
 prop.var
 ```
 
@@ -375,21 +375,17 @@ variance decreases more slowly. The total variance explained up to the elbow poi
 interpreted as structural variance that is relevant and should be retained versus noise
 which may be discarded after the elbow. 
 
+We can create a scree plot using the **`PCAtools`** function `screeplot()`:
+
 
 ```{r varexp}
-# calculate percentage variance explained using output from the PCA
-varExp <- (pca.pros$sdev^2) / sum(pca.pros$sdev^2) * 100
-# create new dataframe with five rows, one for each principal component
-varDF <- data.frame(Dimensions = 1:length(varExp), varExp = varExp)
+screeplot(pca.pros, axisLabSize = 5, titleLabSize = 8)
 ```
 
-```{r vardf-plot, fig.cap="Caption", fig.cap="Alt"}
-plot(varDF)
-```
-
-The screeplot shows that the first principal component explains most of the
+The scree plot shown by the blue bars shows that the first principal component explains most of the
 variance in the data (>50%) and each subsequent principal component explains
-less and less of the total variance. The first two principal components
+less and less of the total variance. The red line displays the cumulative variance explained
+by the principal components and shows that the first two principal components
 explain >70% of variance in the data. But what do these two principal
 components mean?
 

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -446,7 +446,9 @@ is by creating a biplot. Biplots usually show two principal components plotted
 against each other. Observations are sometimes labelled with numbers. The
 contribution of each original variable to the principal components displayed
 is then shown by arrows (generated from those two columns of the rotation matrix that
-correspond to the principal components shown). NB, there are several biplot
+correspond to the principal components shown). See `help("PCAtools::biplot")` for
+arguments and their meaning. For instance, `lab` or `colBy` may be useful.
+Note that there are several biplot
 implementations in different R libraries. It is thus a good idea to specify
 the desired package when calling `biplot()`. A biplot of the first two principal
 components can be generated as follows:
@@ -639,7 +641,7 @@ proportion of variance explained.
 > > ```{r scree-ex, fig.cap="Caption", fig.cap="Alt"}
 > > pc <- pca(mat, metadata = metadata)
 > > screeplot(pc, axisLabSize = 5, titleLabSize = 8, drawCumulativeSumLine = FALSE, 
-> > drawCumulativeSumPoints > > = FALSE) +  geom_line(aes(x = 1:length(pc$components), y = 
+> > drawCumulativeSumPoints = FALSE) +  geom_line(aes(x = 1:length(pc$components), y = 
 > > as.numeric(pc$variance))) #add line to scree plot to visualise the elbow
 > > ``` 
 > > 
@@ -673,8 +675,7 @@ are two functions called `biplot()`, one in the package **`PCAtools`** and one i
 > ## Challenge 5
 > 
 > Create a biplot of the first two principal components from your PCA
-> using `biplot()` function in **`PCAtools`**. See `help("PCAtools::biplot")` for
-> arguments and their meaning. For instance, `lab` or `colBy` may be useful.
+> using `biplot()` function in **`PCAtools`**. 
 > 
 > Examine whether the data appear to form clusters. Explain your results.
 > 

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -316,13 +316,13 @@ deviation of 1.
 
 ## Performing PCA
 
-Throughout this episode, we will carry out PCA using the Bioconductor package **`PCAtools`**.
+Throughout this episode, we will carry out PCA using the Bioconductor package `PCAtools`.
 This package provides several functions that are useful for exploring data via PCA and
 producing useful figures and analysis tools. The package is made for the somewhat unusual
 Bioconductor style of data tables (observations in columns, features in rows). When
-using Bioconductor data sets and **`PCAtools`**, it is thus not necessary to transpose the data.
+using Bioconductor data sets and `PCAtools`, it is thus not necessary to transpose the data.
 You can use the help files in PCAtools to find out about the `pca()`
-function (type `help("pca")` or `?pca` in R). Note that, although we focus on PCA implementation using **`PCAtools`**, there are several other
+function (type `help("pca")` or `?pca` in R). Note that, although we focus on PCA implementation using `PCAtools`, there are several other
 options for performing PCA, including a base R function, `prcomp()`. Equivalent functions and 
 output labels for the common implementations are summarised below.
 
@@ -333,7 +333,7 @@ output labels for the common implementations are summarised below.
 | PCAtools::pca()   | $rotated   | $loadings | 
 
 
-Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. First, let's load the **`PCAtools`** package.
+Let's use the `PCAtools` package to perform PCA on the scaled `prostate` data. First, let's load the `PCAtools` package.
 
 ```{r pcatools}
 library("PCAtools")
@@ -341,7 +341,7 @@ library("PCAtools")
 
 
 The input data (`pros2`) is in the form of a matrix and we need to take the transpose of this 
-matrix and convert it to a data frame for use within the **`PCAtools`** package. We set the `scale = TRUE` argument to standardise the variables to have a mean 0 and standard deviation of 1 as above. 
+matrix and convert it to a data frame for use within the `PCAtools` package. We set the `scale = TRUE` argument to standardise the variables to have a mean 0 and standard deviation of 1 as above. 
 
 ```{r prcomp}
 pros2t <- data.frame(t(pros2))  #create transposed data frame
@@ -380,7 +380,7 @@ variance decreases more slowly. The total variance explained up to the elbow poi
 interpreted as structural variance that is relevant and should be retained versus noise
 which may be discarded after the elbow. 
 
-We can create a scree plot using the **`PCAtools`** function `screeplot()`:
+We can create a scree plot using the `PCAtools` function `screeplot()`:
 
 ```{r varexp, fig.cap="Scree plot showing the percentage of the variance explained by the principal components calculated from the prostate data.", fig.alt="A scree plot showing the percentage of variance explained by each principal component versus the principal component number. The points are joined by lines to indicate where the elbow of the scree plot occurs."}
 screeplot(pca.pros, axisLabSize = 5, titleLabSize = 8, 
@@ -421,7 +421,7 @@ The matrix of loadings (also called rotation matrix) has as many rows as there
 are features in the original data. It contains information about how the
 (usually centered and scaled) original data relate to the principal component scores.
 
-We can print the loadings for the **`PCAtools`** implementation using 
+We can print the loadings for the `PCAtools` implementation using 
 
 ```{r pca-pros}
 pca.pros$loadings
@@ -560,7 +560,7 @@ representing groups of genes would help visualise the data and address
 research questions regarding the effect different groups of genes have on
 disease progression.
 
-Using the **`PCAtools`**, we will apply a PCA to the cancer
+Using the `PCAtools`, we will apply a PCA to the cancer
 gene expression data, plot the amount of variation in the data explained by
 each principal component and plot the most important principal components
 against each other as well as understanding what each principal component
@@ -570,7 +570,7 @@ represents.
 > ## Challenge 3
 > 
 > Apply a PCA to the cancer gene expression data using the `pca()` function from
-> **`PCAtools`**. 
+> `PCAtools`. 
 > 
 > Let us assume we only care about the principal components accounting for the top
 > 80% of the variance in the dataset. Use the `removeVar` argument in `pca()` to remove
@@ -645,7 +645,7 @@ amount of the variation. The proportion of variance explained should sum to one.
 
 > ## Challenge 4
 > 
-> Using the `screeplot()` function in **`PCAtools`**, create a scree plot to show 
+> Using the `screeplot()` function in `PCAtools`, create a scree plot to show 
 > proportion of variance explained by each principal component. Explain the
 > output of the screeplot in terms of proportion of the variance in the data explained
 > by each principal component.
@@ -683,14 +683,14 @@ This will allow any potential clustering of points according to demographic or
 phenotypic variables to be seen.
 
 We can use biplots to look for patterns in the output from the PCA. Note that there
-are two functions called `biplot()`, one in the package **`PCAtools`** and one in
+are two functions called `biplot()`, one in the package `PCAtools` and one in
 **`stats`**. Both functions produce biplots but their scales are different!
 
 
 > ## Challenge 5
 > 
 > Create a biplot of the first two principal components from your PCA
-> using `biplot()` function in **`PCAtools`**. See `help("PCAtools::biplot")` for
+> using `biplot()` function in `PCAtools`. See `help("PCAtools::biplot")` for
 > arguments and their meaning. For instance, `lab` or `colby` may be useful.
 > 
 > Examine whether the data appear to form clusters. Explain your results.
@@ -705,7 +705,7 @@ are two functions called `biplot()`, one in the package **`PCAtools`** and one i
 > > axis according to expressions of different genes while no separation can be
 > > seem along the PC2 axis. Labels of patient samples are automatically added
 > > in the biplot. Labels for each sample are added by default, but can be
-> > removed if there is too much overlap in names. Note that **`PCAtools`** does
+> > removed if there is too much overlap in names. Note that `PCAtools` does
 > > not scale biplot in the same way as biplot using the stats package.
 > {: .solution}
 {: .challenge}
@@ -737,7 +737,7 @@ Let's consider this biplot in more detail, and also display the loadings:
 {: .challenge}
 
 So far, we have only looked at a biplot of PC1 versus PC2 which only gives part
-of the picture. The `pairplots()` function in **`PCAtools`** can be used to create
+of the picture. The `pairplots()` function in `PCAtools` can be used to create
 multiple biplots including different principal components.
 
 ```{r pairsplot, fig.cap="Multiple biplots produced by pairsplot().", fig.alt="An upper triangular grid of scatter plots of each principal component versus the others."}
@@ -753,7 +753,7 @@ you to set custom colours.
 
 Finally, it can sometimes be of interest to compare how certain variables contribute
 to different principal components. This can be visualised with `plotloadings()` from
-the **`PCAtools`** package. The function checks the range of loadings for each
+the `PCAtools` package. The function checks the range of loadings for each
 principal component specified (default: first five principal components). It then selects the features
 in the top and bottom 5% of these ranges and displays their loadings. This behaviour
 can be adjusted with the `rangeRetain` argument, which has 0.1 as the default value (i.e.

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -332,8 +332,14 @@ output labels for the common implementations are summarised below.
 | PCAtools::pca()   | $rotated   | $loadings | 
 
 
-Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. The input
-data (`pros2`) is in the form of a matrix and we set the `scale = TRUE` argument
+Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. Let's load the **`PCAtools`** package and the data.
+
+```{r pcatools}
+library("PCAtools")
+```
+
+
+The input data (`pros2`) is in the form of a matrix and we set the `scale = TRUE` argument
 to standardise the variables to have a mean 0 and standard deviation of 1. 
 
 ```{r prcomp}
@@ -483,11 +489,7 @@ The dataset we will be analysing in this lesson includes two subsets of data:
 * metadata associated with the gene expression results detailing information
   from patients from whom samples were taken.
 
-In this section, we will work through Challenges and you will apply your own PCA to the high-dimensional gene expression data using what we have learnt so far. Let's load the **`PCAtools`** package and the data.
-
-```{r pcatools}
-library("PCAtools")
-```
+In this section, we will work through Challenges and you will apply your own PCA to the high-dimensional gene expression data using what we have learnt so far. 
 
 We will first load the microarray breast cancer gene expression data and
 associated metadata, downloaded from the

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -316,14 +316,14 @@ deviation of 1.
 
 ## Performing PCA
 
-Throughout this episode, we will carry out a PCA using the Bioconductor package **`PCAtools`**.
-This package provides several functions that can be used to explore data via PCA and
-produce useful figures and analysis tools. The package is made for the somewhat unusual
+Throughout this episode, we will carry out PCA using the Bioconductor package **`PCAtools`**.
+This package provides several functions that are useful for exploring data via PCA and
+producing useful figures and analysis tools. The package is made for the somewhat unusual
 Bioconductor style of data tables (observations in columns, features in rows). When
 using Bioconductor data sets and **`PCAtools`**, it is thus not necessary to transpose the data.
 Note that, although we focus on PCA implementation using **`PCAtools`**, there are several other
-options for performing PCA, including a base R function, `prcomp()`. Equivalent functions for 
-the common implementations are summarised below.
+options for performing PCA, including a base R function, `prcomp()`. Equivalent functions and 
+output labels for the common implementations are summarised below.
 
 | library::command()| PC scores | Loadings |
 |-------------------|-----------|----------|

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -560,7 +560,7 @@ representing groups of genes would help visualise the data and address
 research questions regarding the effect different groups of genes have on
 disease progression.
 
-Using the `PCAtools`, we will apply a PCA to the cancer
+Using `PCAtools`, we will perform PCA on the cancer
 gene expression data, plot the amount of variation in the data explained by
 each principal component and plot the most important principal components
 against each other as well as understanding what each principal component

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -354,30 +354,22 @@ We have calculated one principal component for each variable in the original
 dataset. How do we choose how many of these are necessary to represent the true
 variation in the data, without having extra components that are unnecessary?
 
-Let's look at the relative importance of each component using `summary`.
+Let's look at the relative importance of (percentage of the variance explained by) the components:
 
 ```{r summ}
-summary(pca.pros)
-```
-
-```{r, echo = FALSE}
-# Get proportions of variance explained by each PC (rounded to 2 DP)
-prop.var <- round(summary(pca.pros)$importance["Proportion of Variance", ], 2) *
-  100
+prop.var <- round(pc$variance, 4) #round to 4 decimal places
+prop.var
 ```
 
 This returns the proportion of variance in the data explained by each of the
-(p = 5) principal components. In this example, PC1 explains approximately
-`r prop.var[[1]]`% of variance in the data, PC2 `r prop.var[[2]]`% of variance,
-PC3 a further `r prop.var[[3]]`%, PC4 approximately `r prop.var[[4]]`% and PC5
-around `r prop.var[[5]]`%.
+(p = 5) principal components. In this example, the first principal component, PC1, explains approximately
+`r round(prop.var[[1]])`% of variance in the data, PC2 `r round(prop.var[[2]])`% of variance,
+PC3 a further `r round(prop.var[[3]])`%, PC4 approximately `r round(prop.var[[4]])`% and PC5
+around `r round(prop.var[[5]])`%.
 
-Let us visualise this. A plot of the amount of variance accounted for by each PC
-is also called a scree plot. Note that the amount of variance accounted for by a principal
-component is also called eigenvalue and thus the y-axis in scree plots if often
-labelled “eigenvalue”.
-
-Often, scree plots show a characteristic pattern where initially, the variance drops
+Let's visualise this. A plot of the amount of variance accounted for by each PC
+is also called a scree plot. Often, scree plots show a characteristic pattern 
+where initially, the variance drops
 rapidly with each additional principal component. But then there is an “elbow” after which the
 variance decreases more slowly. The total variance explained up to the elbow point is sometimes
 interpreted as structural variance that is relevant and should be retained versus noise

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -332,19 +332,20 @@ output labels for the common implementations are summarised below.
 | PCAtools::pca()   | $rotated   | $loadings | 
 
 
-Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. Let's load the **`PCAtools`** package and the data.
+Let's use the **`PCAtools`** package to perform PCA on the scaled `prostate` data. First, let's load the **`PCAtools`** package and the data.
 
 ```{r pcatools}
 library("PCAtools")
 ```
 
 
-The input data (`pros2`) is in the form of a matrix and we set the `scale = TRUE` argument
+The input data (`pros2`) is in the form of a matrix and we need to take the transpose of this 
+matrix for use within the **`PCAtools`** package. We set the `scale = TRUE` argument
 to standardise the variables to have a mean 0 and standard deviation of 1. 
 
 ```{r prcomp}
-pca.pros <- prcomp(pros2, scale = TRUE, center = TRUE)
-pca.pros
+pc <- pca(t(pros2), scale = TRUE, center = TRUE)
+pc$loadings #return pca loadings 
 ```
 
 # How many principal components do we need?

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -340,12 +340,16 @@ library("PCAtools")
 
 
 The input data (`pros2`) is in the form of a matrix and we need to take the transpose of this 
-matrix for use within the **`PCAtools`** package. We can do this by setting the 
-`transposed = TRUE` argument. We also set the `scale = TRUE` argument
-to standardise the variables to have a mean 0 and standard deviation of 1 as above.
+matrix for use within the **`PCAtools`** package. We set the `scale = TRUE` argument
+to standardise the variables to have a mean 0 and standard deviation of 1 as above. 
 
 ```{r prcomp}
-pca.pros <- pca(t(pros2), scale = TRUE, center = TRUE, transposed = TRUE)
+pros2t <- data.frame(t(pros2))  #create transposed data frame
+colnames(pros2t)<-seq(1:dim(pros2t)[2]) #rename columns for use within PCAtools
+pmetadata= data.frame("M"=rep(1, dim(pros2t)[2]), row.names = colnames(pros2t)) #create fake metadata for use with PCA tools
+
+##implement PCA
+pca.pros <- pca(pros2t, scale = TRUE, center = TRUE,metadata = pmetadata)
 pca.pros$loadings #return pca loadings 
 ```
 
@@ -448,7 +452,7 @@ the desired package when calling `biplot()`. A biplot of the first two principal
 components can be generated as follows:
 
 ```{r stats-biplot, fig.cap="Caption", fig.cap="Alt"}
-PCAtools::biplot(pca.pros, xlim = c(-0.3, 0.3))
+PCAtools::biplot(pca.pros, lab=NULL, singlecol=TRUE) #plot biplot using a single colour for the points
 ```
 
 This biplot shows the position of each patient on a 2-dimensional plot where

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -630,7 +630,7 @@ proportion of variance explained.
 > 
 > Using the `screeplot()` function in **`PCAtools`**, create a screeplot to show 
 > proportion of variance explained by each principal component. Explain the
-> output of the screeplot in terms of proportion of variance in data explained
+> output of the screeplot in terms of proportion of the variance in the data explained
 > by each principal component.
 > 
 > > ## Solution

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -364,13 +364,6 @@ Let's look at the relative importance of (percentage of the variance explained b
 ```{r summ}
 prop.var <- round(pca.pros$variance, 4) #round to 4 decimal places
 prop.var
-summary(pca.pros)
-```
-
-```{r, echo = FALSE}
-# Get proportions of variance explained by each principal component (rounded to 2 decimal places)
-prop.var <- round(summary(pca.pros)$importance["Proportion of Variance", ], 2) *
-  100
 ```
 
 This returns the proportion of variance in the data explained by each of the
@@ -389,15 +382,11 @@ which may be discarded after the elbow.
 
 We can create a scree plot using the **`PCAtools`** function `screeplot()`:
 
-```{r varexp}
+```{r varexp, fig.cap="Scree plot showing the percentage of the variance explained by the principal components calculated from the prostate data.", fig.alt="A scree plot showing the percentage of variance explained by each principal component versus the principal component number. The points are joined by lines to indicate where the elbow of the scree plot occurs."}
 screeplot(pca.pros, axisLabSize = 5, titleLabSize = 8, 
           drawCumulativeSumLine = FALSE, drawCumulativeSumPoints = FALSE) +
     geom_line(aes(x = 1:length(pca.pros$components), y = as.numeric(pca.pros$variance))) 
 #add line to scree plot to visualise the elbow
-```
-
-```{r vardf-plot, fig.cap="Scree plot showing the percentage of the variance explained by the principal components calculated from the prostate data.", fig.alt="A scree plot showing the percentage of variance explained by each principal component versus the principal component number. The points are joined by lines to indicate where the elbow of the scree plot occurs."}
-plot(varDF, type="b")
 ```
 
 The scree plot shows that the first principal component explains most of the
@@ -481,8 +470,8 @@ the desired package when calling `biplot()`. A biplot of the first two principal
 components can be generated as follows:
 
 
-```{r stats-biplot, fig.cap="Scatter plot of the first two principal components with observations numerically labelled. The loadings are shown by red arrows.", fig.alt="Scatter plot of the second principal component versus the first principal component. Observations as points, numerically labelled. The loadings are shown by red arrows, each labelled by their associated variable."}
-stats::biplot(pca.pros, xlim = c(-0.3, 0.3))
+```{r stats-biplot, fig.cap="Scatter plot of the first two principal components with observations numerically labelled.", fig.alt="Scatter plot of the second principal component versus the first principal component. Observations as points, numerically labelled."}
+PCAtools::biplot(pca.pros)
 ```
 
 This biplot shows the position of each patient on a 2-dimensional plot where
@@ -595,7 +584,7 @@ represents.
 > > ```{r pca-ex}
 > > pc <- pca(mat, metadata = metadata) # implement a PCA
 > > #We can check the scree plot to see that many principal components explain a very small amount of
-> > the total variance in the data
+> > #the total variance in the data
 > > 
 > > #Let's remove the principal components with lowest 20% of the variance
 > > pc <- pca(mat, metadata = metadata, removeVar = 0.2)
@@ -604,12 +593,14 @@ represents.
 > > pc$loadings[1:5, 1:5] #obtain the first 5 principal component loadings for the first 5 features
 > > 
 > > which.max(pc$loadings[, 1]) # index of the maximal loading for the first principal component
-> > pc$loadings[which.max(pc$loadings[, 1]), ] # principal component loadings for the feature
-> > with the maximal loading on the first principal component.
+> > # principal component loadings for the feature
+> > #with the maximal loading on the first principal component:
+> > pc$loadings[which.max(pc$loadings[, 1]), ] 
 > > 
 > > which.max(pc$loadings[, 2]) # index of the maximal loading for the second principal component
-> > pc$loadings[which.max(pc$loadings[, 2]), ] # principal component loadings for the feature
-> > with the maximal loading on the second principal component.
+> > # principal component loadings for the feature
+> > #with the maximal loading on the second principal component:
+> > pc$loadings[which.max(pc$loadings[, 2]), ] 
 > > ```
 > > The function `pca()` is used to perform PCA, and uses as input a matrix
 > > (`mat`) containing continuous numerical data
@@ -663,9 +654,10 @@ amount of the variation. The proportion of variance explained should sum to one.
 > > 
 > > ```{r scree-ex, fig.cap="Caption", fig.cap="Alt"}
 > > pc <- pca(mat, metadata = metadata)
+> > #Add line to scree plot to visualise the elbow
 > > screeplot(pc, axisLabSize = 5, titleLabSize = 8, drawCumulativeSumLine = FALSE, 
 > > drawCumulativeSumPoints = FALSE) +  geom_line(aes(x = 1:length(pc$components), y = 
-> > as.numeric(pc$variance))) #add line to scree plot to visualise the elbow
+> > as.numeric(pc$variance))) 
 > > ``` 
 > > 
 > > The first principal component explains around 33% of the 

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -636,6 +636,7 @@ proportion of variance explained.
 > > ## Solution
 > > 
 > > ```{r scree-ex, fig.cap="Caption", fig.cap="Alt"}
+> > pc <- pca(mat, metadata = metadata)
 > > screeplot(pc, axisLabSize = 5, titleLabSize = 8)
 > > ```
 > > Note that first principal component (PC1) explains more variation than

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -639,26 +639,26 @@ proportion of variance explained.
 > > pc <- pca(mat, metadata = metadata)
 > > screeplot(pc, axisLabSize = 5, titleLabSize = 8)
 > > ```
-> > Note that first principal component (PC1) explains more variation than
-> > other principal components (which is always the case in PCA). The screeplot
-> > shows that the first principal component only explains ~33% of the total
-> > variation in the micrarray data and many principal components explain very 
-> > little variation. The red line shows the cumulative percentage of explained
-> > variation with increasing principal components. Note that in this case 18
-> > principal components are needed to explain over 75% of variation in the
-> > data. This is not an unusual result for complex biological datasets
-> > including genetic information as clear relationships between groups are
-> > sometimes difficult to observe in the data. The screeplot shows that using
-> > a PCA we have reduced 91 predictors to 18 in order to explain a significant
-> > amount of variation in the data. See additional arguments in screeplot
-> > function for improving the appearance of the plot.
+> > The red line shows the cumulative percentage of explained
+> > variation with increasing principal components. The first 
+> > principal component explains around 33% of the 
+> > variance in the microarray data, the first 4 principal components explain
+> > around 50%, and 20 principal components explain around 75%. Many principal 
+> > components explain very little variation. Looking at the scree plot, the
+> > 'elbow' appears to be around 4-5 principal components, indicating that this
+> > may be a suitable number of principal components. However, these principal components 
+> > cumulatively explain only 51-55% of the variance in the dataset. Although the fact we 
+> > are able to summarise most of the information in the complex dataset in 4-5 principal components
+> > may be a useful result, we may opt to retain more principal 
+> > components (for example, 20) to capture more of the variability 
+> > in the dataset depending on research question.
 > {: .solution}
 {: .challenge}
 
 ## Investigating the principal components 
 
 Once the most important principal components have been identified using
-`screeplot()`, these can be explored in more detail by plotting principal components
+`screeplot()` and explored, these can be explored in more detail by plotting principal components
 against each other and highlighting points based on variables in the metadata.
 This will allow any potential clustering of points according to demographic or
 phenotypic variables to be seen.


### PR DESCRIPTION
Largely trying to introduce consistent package use throughout as in #117 - this version only uses PCAtools and provides the table for conversion to base R PCA functions.

I have also introduced a consistent scree plot definition (variance explained rather than cumulative) in line with what I believe to be the standard definition - though absolutely feel free to correct me! PCAtools plots both, which is informative, but possibly not a scree plot and therefore confusing.

This will be ugly to merge with the other pull requests related to this issue but happy to work my way through these as we go.