### PR TITLE
Changes to episode timings and instructor notes

### DIFF
--- a/_episodes_rmd/01-introduction-to-high-dimensional-data.Rmd
+++ b/_episodes_rmd/01-introduction-to-high-dimensional-data.Rmd
@@ -2,7 +2,7 @@
 title: "Introduction to high-dimensional data"
 author: "GS Robertson"
 source: Rmd
-teaching: 20
+teaching: 30
 exercises: 20
 questions:
 - What are high-dimensional data and what do these data look like in the

--- a/_episodes_rmd/02-high-dimensional-regression.Rmd
+++ b/_episodes_rmd/02-high-dimensional-regression.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "Regression with many outcomes"
 source: Rmd
-teaching: 60
-exercises: 30
+teaching: 70
+exercises: 50
 questions:
 - "How can we apply linear regression in a high-dimensional setting?"
 - "How can we benefit from the fact that we have many outcomes?"

--- a/_episodes_rmd/03-regression-regularisation.Rmd
+++ b/_episodes_rmd/03-regression-regularisation.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "Regularised regression"
 source: Rmd
-teaching: 60
-exercises: 20
+teaching: 110
+exercises: 60
 questions:
 - "What is regularisation?"
 - "How does regularisation work?"

--- a/_episodes_rmd/04-principal-component-analysis.Rmd
+++ b/_episodes_rmd/04-principal-component-analysis.Rmd
@@ -3,7 +3,7 @@ title: "Principal component analysis"
 author: "GS Robertson"
 source: Rmd
 teaching: 90
-exercises: 30
+exercises: 40
 questions:
 - What is principal component analysis (PCA) and when can it be used?
 - How can we perform a PCA in R?

--- a/_episodes_rmd/05-factor-analysis.Rmd
+++ b/_episodes_rmd/05-factor-analysis.Rmd
@@ -2,7 +2,7 @@
 title: "Factor analysis"
 author: "GS Robertson"
 source: Rmd
-teaching: 25
+teaching: 30
 exercises: 10
 questions:
 - What is factor analysis and when can it be used?

--- a/_episodes_rmd/06-k-means.Rmd
+++ b/_episodes_rmd/06-k-means.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "K-means"
 source: Rmd
-teaching: 45
-exercises: 15
+teaching: 60
+exercises: 20
 questions:
   - How do we detect real clusters in high-dimensional data?
   - How does K-means work and when should it be used?

--- a/_episodes_rmd/07-hierarchical.Rmd
+++ b/_episodes_rmd/07-hierarchical.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "Hierarchical clustering"
 source: Rmd
-teaching: 60
-exercises: 10
+teaching: 70
+exercises: 20
 questions:
 - What is hierarchical clustering and how does it differ from other clustering methods?
 - How do we carry out hierarchical clustering in R?

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -13,7 +13,7 @@ Session 1:
 - Regression with many outcomes (episode 2): 70 minutes of teaching time, 50 minutes for exercises (total: 120 minutes).
 
 Session 2:
-- Regression with many outcomes (episode 3): 110 minutes of teaching time, 60 minutes for exercises (total: 170 minutes).
+- Regularised regression (episode 3): 110 minutes of teaching time, 60 minutes for exercises (total: 170 minutes).
 
 Session 3:
 - Principal component analysis (episode 4): 90 minutes of teaching time, 40 minutes for exercises (total: 130 minutes).

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,6 +1,26 @@
 ---
 title: "Instructor Notes"
 ---
-Coming soon.
+
+Thank you for teaching high dimensional statistics with R! We hope you enjoy teaching the lesson. This page contains additional information for instructors.
+
+The materials for each episode are self-contained and can be found through the episode links on the home page. The slides in the Extras section can be used to supplement these materials.
+
+In previous rounds of teaching, the lesson was taught in four sessions, each lasting 2 hours and 50 minutes. We also advise allowing around 40 minutes of additional time for breaks. The recommended timings for each session are as follows:
+
+Session 1: 
+- Introduction to high-dimensional data (episode 1): 30 minutes of teaching time, 20 minutes for exercises (total: 50 minutes).
+- Regression with many outcomes (episode 2): 70 minutes of teaching time, 50 minutes for exercises (total: 120 minutes).
+
+Session 2:
+- Regression with many outcomes (episode 3): 110 minutes of teaching time, 60 minutes for exercises (total: 170 minutes).
+
+Session 3:
+- Principal component analysis (episode 4): 90 minutes of teaching time, 40 minutes for exercises (total: 130 minutes).
+- Factor analysis (episode 5): 30 minutes of teaching time, 10 minutes for exercises (total: 40 minutes).
+
+Session 4:
+- K-means (episode 6): 60 minutes of teaching time, 20 minutes for exercises (total: 80 minutes).
+- Hierarchical clustering (episode 7): 70 minutes of teaching time, 20 minutes for exercises (total: 90 minutes).
 
 {% include links.md %}

--- a/reference.md
+++ b/reference.md
@@ -4,6 +4,5 @@ layout: reference
 
 ## Glossary
 
-Coming soon. Feel free to suggest entries via GitHub Issues!
 
 {% include links.md %}


### PR DESCRIPTION
I've had a go at adjusting the timings for each episode, largely to

- Match sessions to the 2 hour 50 minute threshold for each session (session 1: episodes 1 and 2, session 2: episode 3, session 3: episodes 4 and 5, session 4: episodes 6 and 7). I believe these are the session/episode splits used in all previous rounds of teaching.
- Increase the proportion of the time spent on challenges, particularly for the first 3 episodes as per the feedback. I went through the challenges to check and have also increased the amount of challenge time for episode 4 - the challenges in this episode are quite involved. Otherwise, the timings for each episode and teaching/challenge splits have been increased roughly proportionally to the original timings.
- Have also filled out the instructor notes and included these timings with a note about breaks. This may need to be checked in detail because I haven't taught the course so may be missing things!

To double check, will changing the yaml parameters at the start of each episode like this change the home page timings?

Addresses #112, #133, #145