### PR TITLE
Linux/mac fix for setup

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -9,8 +9,10 @@ to set up for the lessons. This should take about an hour to run, depending on
 the speed of your computer, your internet connection, and any packages you have
 installed already. You'll need to install R 4.0 or later.
 
-The following code will download the data and install the libraries
-used in the current version of this lesson:
+On Linux and Mac systems, R package installation often requires additional system dependencies. To ensure that you can download packages using the code below, first run the terminal commands for your Linux distribution [here](https://docs.posit.co/connect/admin/r/dependencies/). For Mac systems, you can use the Ubuntu code. Note that you will need to use root access (sudo) to install the system dependencies. Windows users can skip this step.
+
+All learners should then run the following code to download the data and install the libraries
+used in this lesson:
 
 ```r
 install.packages("BiocManager")
@@ -39,18 +41,5 @@ for (file in data_files) {
     )
 }
 ```
-
-On Linux systems, part of the above may fail due to the **`bluster`** package and you may receive error messages after running `BiocManager::install(table[[1]])`, indicating that the package `igraph` was not installed successfully. 
-
-Detailed installation instructions for `igraph` can be found at [https://r.igraph.org/](https://r.igraph.org/), but the following workaround code may resolve the issue:
-
-```r
-install.packages('igraph', repos=c(igraph = 'https://igraph.r-universe.dev', 
-                                   CRAN = 'https://cloud.r-project.org'))
-                                   
-BiocManager::install('bluster')
-```
-
-Note especially the C libraries that are mentioned on the `igraph` help page for compiling from source --- these are usually available via a package manager (homebrew, apt, pacman, etc), and are required if your R installation is unable to use pre-compiled binaries from CRAN.
 
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -9,7 +9,7 @@ to set up for the lessons. This should take about an hour to run, depending on
 the speed of your computer, your internet connection, and any packages you have
 installed already. You'll need to install R 4.0 or later.
 
-On Linux and Mac systems, R package installation often requires additional system dependencies. To ensure that you can download packages using the code below, first run the terminal commands for your Linux distribution [here](https://docs.posit.co/connect/admin/r/dependencies/). For Mac systems, you can use the Ubuntu code. Note that you will need to use root access (sudo) to install the system dependencies. Windows users can skip this step.
+On Linux and Mac systems, R package installation often requires additional system dependencies. If you are a Linux or Mac user, to ensure that you can download packages using the code below, first run the terminal commands for your distribution [here](https://docs.posit.co/connect/admin/r/dependencies/). For Mac systems, you can use the Ubuntu code. Note that you will need to use root access (sudo) to install the system dependencies. Windows users can skip this step.
 
 All learners should then run the following code to download the data and install the libraries
 used in this lesson:

--- a/setup.md
+++ b/setup.md
@@ -9,7 +9,18 @@ to set up for the lessons. This should take about an hour to run, depending on
 the speed of your computer, your internet connection, and any packages you have
 installed already. You'll need to install R 4.0 or later.
 
-On Linux and Mac systems, R package installation often requires additional system dependencies. If you are a Linux or Mac user, to ensure that you can download packages using the code below, first run the terminal commands for your distribution [here](https://docs.posit.co/connect/admin/r/dependencies/). For Mac systems, you can use the Ubuntu code. Note that you will need to use root access (sudo) to install the system dependencies. Windows users can skip this step.
+R usually enables package downloads using pre-built binaries. Some times, this is not possible,
+particularly on Linux and Mac systems. In this case, R package installation often requires additional
+system dependencies. If you are a Linux user, to ensure that you can download packages using the code 
+below, first run the terminal commands for your distribution
+[here](https://docs.posit.co/connect/admin/r/dependencies/).
+Note that you will need to use root access (sudo) to install the system dependencies.
+Mac users may need to use [homebrew](https://brew.sh/) to install system dependencies,
+and Windows users may need to install [RTools](https://cran.r-project.org/bin/windows/Rtools/).
+Ideally, installing packages will proceed without error and you can ignore these steps,
+but this isn't always the case.
+
+Previous learners have reported issues with **`igraph`**. Installation instructions for this package can be found on [https://r.igraph.org/](https://r.igraph.org/),
 
 All learners should then run the following code to download the data and install the libraries
 used in this lesson:


### PR DESCRIPTION
This definitely needs looking at/tested, especially on Mac. I tested on Linux and it seems to work and removes igraph/minfi issues.

To explain PR:
- Because the second link in #160 requires a mixture of R and bash to install dependencies, it could be easier to use the first link and require all system dependencies are installed. Checked the latter and the dependencies don't seem to take too long to install. Could replace the Linux caveat (currently about igraph) with something similar to the code I've proposed.
- Tested on Ubuntu without any problems and seems to resolve igraph issue. I actually don't know that the Ubuntu code can be used on Mac as stated in this new version so will need to be tested/checked (my understanding is that the Mac terminal uses bash?).